### PR TITLE
Add feature flags to ignore some errors during server certificate import

### DIFF
--- a/geteduroam.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/geteduroam.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/egeniq/app-remote-config",
       "state" : {
-        "revision" : "f5220e4ad1ab5b31981beec6ed361eaf7405c5e9",
-        "version" : "0.0.4"
+        "revision" : "0ab2f3e3b3d5cc0a41112cbd8b4adb9079323373",
+        "version" : "0.2.0"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/egeniq/app-remote-config-ios",
       "state" : {
-        "revision" : "5d5ea451ca73bcd53f818d0d0302d824a69203ea",
-        "version" : "0.0.3"
+        "revision" : "858aa2ee1b2a1a2a3f1389f1cdb7543770acb43b",
+        "version" : "0.2.0"
       }
     },
     {

--- a/geteduroam/GeteduroamPackage/Package.swift
+++ b/geteduroam/GeteduroamPackage/Package.swift
@@ -42,7 +42,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/CoreOffice/XMLCoder", .upToNextMajor(from: "0.16.0")),
-        .package(url: "https://github.com/egeniq/app-remote-config-ios", from: "0.0.2"),
+        .package(url: "https://github.com/egeniq/app-remote-config-ios", from: "0.2.0"),
         .package(url: "https://github.com/egeniq/network-ios", branch: "main"),
         .package(url: "https://github.com/openid/AppAuth-iOS", from: "1.0.0"),
         .package(url: "https://github.com/pointfreeco/swift-composable-architecture", from: "1.8.0"),
@@ -146,6 +146,7 @@ let package = Package(
         .target(
             name: "EAPConfigurator",
             dependencies: [
+                "AppRemoteConfigClient",
                 "Models",
                 .product(name: "Dependencies", package: "swift-dependencies")
             ]),

--- a/geteduroam/GeteduroamPackage/Sources/AppRemoteConfigClient/AppRemoteConfigClient.swift
+++ b/geteduroam/GeteduroamPackage/Sources/AppRemoteConfigClient/AppRemoteConfigClient.swift
@@ -9,6 +9,14 @@ public enum AppState: String, CaseIterable {
     case active, updateRecommended, updateRequired, updateOSRecommended, updateOSRequired, obsolete, disabled
 }
 
+public struct IgnoreServerCertificateImportFailureEnabled {
+    fileprivate init() { }
+}
+
+public struct IgnoreMissingServerCertificateNameEnabled {
+    fileprivate init() { }
+}
+
 /// Remotely configurable values
 @AppRemoteConfigValues @Perceptible
 public class Values {
@@ -29,6 +37,14 @@ public class Values {
     
     /// Enabled when the API is undergoing maintenance
     public fileprivate(set) var maintenance: Bool = false
+    
+    /// A feature flag to ignore failed server certificate import
+    fileprivate var ignoreServerCertificateImportFailure: Bool = false
+    public var ignoreServerCertificateImportFailureEnabled: IgnoreServerCertificateImportFailureEnabled? { ignoreServerCertificateImportFailure ? IgnoreServerCertificateImportFailureEnabled() : nil }
+    
+    /// A feature flag to ignore missing server certificate name
+    fileprivate var ignoreMissingServerCertificateName: Bool = false
+    public var ignoreMissingServerCertificateNameEnabled: IgnoreMissingServerCertificateNameEnabled? { ignoreMissingServerCertificateName ? IgnoreMissingServerCertificateNameEnabled() : nil }
 }
 
 @Perceptible
@@ -100,6 +116,20 @@ public struct ValuesEditor: View {
                         Text("maintenance".camelCaseToWords())
                     }
                 }
+                
+                Section(
+                    content: {
+                        Toggle(isOn: $values.ignoreServerCertificateImportFailure) {
+                            Text("ignoreServerCertificateImportFailure".camelCaseToWords())
+                        }
+                        Toggle(isOn: $values.ignoreMissingServerCertificateName) {
+                            Text("ignoreMissingServerCertificateName".camelCaseToWords())
+                        }
+                    },
+                    header: {
+                        Text("Connecting")
+                    }
+                )
             }
         }
     }


### PR DESCRIPTION
Feature flags for issue #122

**Instructions for testing "No valid outer EAP type in configuration" workaround**

1. Install build from TestFlight version 2.4 (build <look this up>)
2. Type "geheim" in the search field
3. Select text, tap and copy to pasteboard
4. Tap at least 10 times quickly on the white eduroam logo
5. Tap and hold the search icon
6. Choose "App configuration" from the menu
7. Enable "Ignore Server Certificate Import Failure" and/or "Ignore Missing Certificate Name" toggles
8. Swipe down to close the menu
9. Go through connect flow

Note: the flags are reset when the app is relaunched
