### PR TITLE
Use first entry if language not found and any not set

### DIFF
--- a/geteduroam/GeteduroamPackage/Sources/Models/DiscoveryVersion.swift
+++ b/geteduroam/GeteduroamPackage/Sources/Models/DiscoveryVersion.swift
@@ -6,7 +6,7 @@ public struct DiscoveryVersion: Codable, Equatable {
     }
     
     enum CodingKeys: String, CodingKey {
-        case organizations =  "providers"
+        case organizations = "providers"
     }
     
     public let organizations: [Organization]

--- a/geteduroam/GeteduroamPackage/Sources/Models/LocalizedEntry.swift
+++ b/geteduroam/GeteduroamPackage/Sources/Models/LocalizedEntry.swift
@@ -18,8 +18,11 @@ public struct LocalizedEntry: Codable, Equatable, Sendable {
 
 extension [LocalizedEntry] {
     public func localized(for languageCode: String? = Locale.current.languageCode) -> String? {
+        // When the requested language isn't there:
+        // 1. find entry with language "any" or language not set
+        // 2. use first entry
         func fallback() -> String? {
-            first(where: { $0.language == "any" || $0.language == nil })?.value
+            first(where: { $0.language == "any" || $0.language == nil })?.value ?? first?.value
         }
         guard let language = languageCode else {
             return fallback()

--- a/geteduroam/GeteduroamPackage/Tests/ModelsTests/LocalizedEntryTests.swift
+++ b/geteduroam/GeteduroamPackage/Tests/ModelsTests/LocalizedEntryTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+import XMLCoder
+import CustomDump
+@testable import Models
+
+final class LocalizedEntryTests: XCTestCase {
+    
+    func testLocalizationWithNilLanguage() throws {
+        let sut = [
+            LocalizedEntry(language: nil, value: "No lang value"),
+            LocalizedEntry(language: "nl", value: "NL value")
+        ]
+        
+        XCTAssertEqual("No lang value", sut.localized(for: "en"))
+        XCTAssertEqual("NL value", sut.localized(for: "nl"))
+    }
+    
+    func testLocalizationWithAnyLanguage() throws {
+        let sut = [
+            LocalizedEntry(language: "any", value: "No lang value"),
+            LocalizedEntry(language: "nl", value: "NL value")
+        ]
+        
+        XCTAssertEqual("No lang value", sut.localized(for: "en"))
+        XCTAssertEqual("NL value", sut.localized(for: "nl"))
+    }
+    
+    func testLocalizationWithoutAnyLanguage() throws {
+        let sut = [
+            LocalizedEntry(language: "nl", value: "NL value"),
+            LocalizedEntry(language: "dk", value: "DK value")
+        ]
+        
+        XCTAssertEqual("NL value", sut.localized(for: "en"))
+        XCTAssertEqual("NL value", sut.localized(for: "nl"))
+        XCTAssertEqual("DK value", sut.localized(for: "dk"))
+    }
+    
+    func testLocalizationWithSingleLanguage() throws {
+        let sut = [
+            LocalizedEntry(language: "nl", value: "NL value")
+        ]
+        
+        XCTAssertEqual("NL value", sut.localized(for: "en"))
+        XCTAssertEqual("NL value", sut.localized(for: "nl"))
+        XCTAssertEqual("NL value", sut.localized(for: "dk"))
+    }
+
+}


### PR DESCRIPTION
Fixes #132